### PR TITLE
Update tcleaner

### DIFF
--- a/tcleaner/usr/bin/tcleaner
+++ b/tcleaner/usr/bin/tcleaner
@@ -68,7 +68,7 @@ echo -e "${BR}[!]${NC} Developed by Noah Little (@noahacks)"
 echo -e "${BR}[!]${NC} Please don't rebrand this product and re-release!"
 sleep 2
 if [[ $EUID -ne 0 ]]; then
-   echo -e "${BR}[!]${NC} TCLEANER requires root privileges, exiting..." 
+   echo -e "${BR}[!]${NC} $(echo ${0} | cut -d '/' -f 2 | cut -d ' ' -f 2) requires root privileges, please use ${RED}sudo ${0}" 
    exit 1
 fi
 sleep 2


### PR DESCRIPTION
${0} is the executable name, so if they renamed the file `CleanUp`, `./CleanUp` would show

    [!] CleanUp requires root privileges, please use sudo ./CleanUp" 

${0} can produce two different outputs:

    bash CleanUp

and

    ./CleanUp

so `$(echo ${0} | cut -d '/' -f 2 | cut -d ' ' -f 2)` gets everything after either `<space>` or `/`, meaning it always gets the executable name